### PR TITLE
Add `dnsutils` to container dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN set -x && \
     python \
     python3-dev \
     uuid-runtime \
+    dnsutils \
     && \
     git config --global advice.detachedHead false && \
     echo "========== Install mlat-client ==========" && \


### PR DESCRIPTION
Running this on a K8s cluster can cause some interesting DNS issues. On the default settings, `ndots` is 5, which means that `adsbexchange.com` attempts to be resolved to `adsbexchange.com.<namespace>.svc.cluster.local` as well as every other DNS extension configured. Reducing `ndots` to 1 gives this output:

```
[adsbexchange-stats] /usr/local/bin/json-status: line 127: host: command not found
[adsbexchange-stats] Failure resolving [adsbexchange.com], waiting and trying again...
```

Adding `dnsutils` to the dependencies provides `host` and `adsbexchange-feed` can then connect.