### PR TITLE
Add `MLAT_INPUT_TYPE` environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@ ENV ADSBX_JSON_PATH="/run/adsbexchange-feed" \
     REDUCE_INTERVAL="0.5" \
     S6_BEHAVIOUR_IF_STAGE2_FAILS=2 \
     UUID_FILE="/boot/adsbx-uuid" \
-    PRIVATE_MLAT="false"
+    PRIVATE_MLAT="false" \
+    MLAT_INPUT_TYPE="dump1090"
 
 RUN set -x && \
     apt-get update -y && \

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ There are a series of available environment variables:
 | `TZ`                 | Optional. Your local timezone                                            | `GMT`     |
 | `REDUCE_INTERVAL`    | Optional. How often beastreduce data is transmitted to ADSBExchange. For low bandwidth feeds, this can be increased to `5` or even `10` | `0.5`     |
 | `PRIVATE_MLAT`       | Optional. Setting this to true will prevent feeder being shown on the [ADS-B Exchange Feeder Map](https://map.adsbexchange.com/mlat-map/)| `false`     |
+| `MLAT_INPUT_TYPE`    | Optional. Sets the input receiver type.                                  | `dump1090` |
 
 ## Ports
 

--- a/etc/services.d/mlat-client/run
+++ b/etc/services.d/mlat-client/run
@@ -2,7 +2,7 @@
 # shellcheck shell=bash
 
 MLAT_CMD="mlat-client"
-MLAT_PARAM=(--input-type beast)
+MLAT_PARAM=(--input-type "${MLAT_INPUT_TYPE}")
 MLAT_PARAM+=(--no-udp)
 MLAT_PARAM+=(--input-connect "${BEASTHOST}:${BEASTPORT}")
 MLAT_PARAM+=(--server feed.adsbexchange.com:31090)


### PR DESCRIPTION
Expose `mlat-client`'s `--input-type`, for people using alternative ADS-B receivers.