### PR TITLE
Implement issue #22

### DIFF
--- a/etc/cont-init.d/01-adsbexchange
+++ b/etc/cont-init.d/01-adsbexchange
@@ -39,6 +39,14 @@ if [ $EXITCODE -ne 0 ]; then
   exit 1
 fi
 
+# Check to make sure ALT includes "m" or "ft" suffix if positive
+echo "${ALT}" | grep -P '(^\-{0}\d+(m|ft)$|^-\d+$)' > /dev/null 2>&1
+if [ "$?" -ne "0" ]; then
+  echo -e "${LIGHTRED}ERROR: ALT should be either:"
+  echo -e "  * A positive integer ending in 'm' (for metres) or 'ft' (for feet)'; or"
+  echo -e "  * A negative integer in metres (no suffix) for below sea level.${NOCOLOR}"
+fi
+
 # Set up timezone
 if [ -z "${TZ}" ]; then
   echo -e "${YELLOW}WARNING: TZ environment variable not set${NOCOLOR}"


### PR DESCRIPTION
Add sanity checks for ALT environment variable. ALT should be either:
  * A positive integer ending in 'm' (for metres) or 'ft' (for feet)'; or
  * A negative integer in metres (no suffix) for below sea level.