### PR TITLE
Update ALT sanity check regex

### DIFF
--- a/etc/cont-init.d/01-adsbexchange
+++ b/etc/cont-init.d/01-adsbexchange
@@ -40,10 +40,11 @@ if [ $EXITCODE -ne 0 ]; then
 fi
 
 # Check to make sure ALT includes "m" or "ft" suffix if positive
-echo "${ALT}" | grep -P '(^\-{0}\d+(m|ft)$|^-\d+$)' > /dev/null 2>&1
+echo "${ALT}" | grep -P '(^\-{0}\d+(m{0,1}|ft)$|^-\d+$)' > /dev/null 2>&1
 if [ "$?" -ne "0" ]; then
   echo -e "${LIGHTRED}ERROR: ALT should be either:"
   echo -e "  * A positive integer ending in 'm' (for metres) or 'ft' (for feet)'; or"
+  echo -e "  * A positive integer with no suffix (for metres)"
   echo -e "  * A negative integer in metres (no suffix) for below sea level.${NOCOLOR}"
 fi
 


### PR DESCRIPTION
ALT now requires:
* A positive integer ending in 'm' (for metres) or 'ft' (for feet)'; or
* A positive integer with no suffix (for metres)
* A negative integer in metres (no suffix) for below sea level.

As-per TanerH's comments in ADSB discord.

> yeah you need "ft" on the end, if it's in feet.
> no suffix, or 'm' suffix, means meters
> ALSO: negative altitudes MUST be in meters, with no suffix