### PR TITLE
Add fix for issue #41

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Pull hadolint/hadolint:latest Image
       run: docker pull hadolint/hadolint:latest
     - name: Run hadolint against Dockerfiles
-      run: docker run --rm -i -v "$PWD":/workdir --workdir /workdir --entrypoint hadolint hadolint/hadolint --ignore DL3008 --ignore SC2068 $(find . -type f -iname "Dockerfile*")
+      run: docker run --rm -i -v "$PWD":/workdir --workdir /workdir --entrypoint hadolint hadolint/hadolint --ignore DL3008 --ignore SC2068 --ignore DL3013 $(find . -type f -iname "Dockerfile*")
 
   markdownlint:
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -93,7 +93,7 @@ RUN set -x && \
     mv readsb /usr/local/bin/ && \
     popd && \
     # Deploy adsbexchange-stats
-    python3 -m pip install vcgencmd && \
+    python3 -m pip install --no-cache-dir vcgencmd && \
     git clone "${URL_ADSBX_STATS}" /src/adsbexchange-stats && \
     pushd /src/adsbexchange-stats && \
     echo "adsbexchange-stats $(git log | head -1)" >> /VERSIONS && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -94,7 +94,7 @@ RUN set -x && \
     pushd /src/raspberrypi/userland && \
     # Remove sudo - this script runs as root
     sed -i 's/sudo//g' ./buildme && \
-    ./buildme --$(uname -m) && \
+    ./buildme "--$(uname -m)" && \
     echo '/opt/vc/lib' > /etc/ld.so.conf.d/rpi_userland.conf && \
     ldconfig && \
     popd && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,9 @@ RUN set -x && \
     TEMP_PACKAGES+=(debhelper) && \
     TEMP_PACKAGES+=(python3-dev) && \
     KEPT_PACKAGES+=(python3) && \
+    TEMP_PACKAGES+=(python3-pip) && \
+    TEMP_PACKAGES+=(python3-wheel) && \
+    TEMP_PACKAGES+=(python3-setuptools) && \
     TEMP_PACKAGES+=(python-distutils-extra) && \
     # Install packages
     apt-get update && \
@@ -90,6 +93,7 @@ RUN set -x && \
     mv readsb /usr/local/bin/ && \
     popd && \
     # Deploy adsbexchange-stats
+    python3 -m pip install vcgencmd && \
     git clone "${URL_ADSBX_STATS}" /src/adsbexchange-stats && \
     pushd /src/adsbexchange-stats && \
     echo "adsbexchange-stats $(git log | head -1)" >> /VERSIONS && \

--- a/rootfs/scripts/vcgencmd_get_throttled_wrapper.sh
+++ b/rootfs/scripts/vcgencmd_get_throttled_wrapper.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2181
 
 # Fix for issue #41 (https://github.com/mikenye/docker-adsbexchange/issues/41)
 

--- a/rootfs/scripts/vcgencmd_get_throttled_wrapper.sh
+++ b/rootfs/scripts/vcgencmd_get_throttled_wrapper.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Fix for issue #41 (https://github.com/mikenye/docker-adsbexchange/issues/41)
+
+# Set correct path
+PATH=$PATH:/opt/vc/bin
+
+# Check if 'vcgencmd' exists
+if which vcgencmd > /dev/null; then
+  # Attempt to call 'vcgencmd get_throttled'.
+  VCGENCMD_GET_THROTTLED=$(vcgencmd get_throttled 2>&1)
+  if [[ "$?" -ne 0 ]]; then
+    # If the command works (ie, user is on RPi and has forwarded the /dev/vhci into the container), then use that output.
+    echo "$VCGENCMD_GET_THROTTLED"
+  else
+    # If the exit status of vcgencmd is not 0, then spoof the output with throttled=0x0
+    echo "throttled=0x0"
+  fi
+else
+  # If 'vcgencmd' doesn't exist, then spoof the output with throttled=0x0
+  echo "throttled=0x0"
+fi


### PR DESCRIPTION
Add fix for:

```
[adsbexchange-stats] /usr/local/bin/json-status: line 299: vcgencmd: command not found
```

This is due to this inclusion by the adsbx team: https://github.com/adsbxchange/adsbexchange-stats/blob/50035d990a6270be9edfea30655558d9c89fa1cb/json-status#L299

I've experimented with adding `vcgencmd` to the image, however without presenting the device `/dev/vchi` into the container, the `vcgencmd` command errors with:

```
VCHI initialization failed
```

My proposed solution is:

 * During image build, modify the adsbexchange-stats/json-status script with sed to change `STATUS=$(vcgencmd get_throttled)` to `STATUS=$(vcgencmd_get_throttled_wrapper.sh)`
 * Create `vcgencmd_get_throttled_wrapper.sh` that attempts to call `vcgencmd get_throttled`.
   * If the exit status of `vcgencmd` is not `0`, or of `vcgencmd` doesn't exist, then spoof the output with `throttled=0x0`
   * If the command works (ie, user is on RPi and has forwarded the `/dev/vhci` into the container), then use that output.
