### PR TITLE
correct tmpfs argument in docker run readme, add missing backslash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -135,6 +135,7 @@ RUN set -x && \
     chown adsbx:adsbx /boot/adsbx-uuid && \
     # Set up symlinks for /etc/localtime & permissions for /etc/timezone for rootless operation
     chown adsbx:adsbx /etc/timezone && \
+    chown adsbx:adsbx /run && \
     rm /etc/localtime && \
     ln -s /tmp/localtime /etc/localtime && \
     # Fix /etc/s6/init/init-stage2-fixattrs.txt for rootless operation

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ docker run \
  -e ALT=50m \
  -e SITENAME=My_Cool_ADSB_Receiver \
  -e UUID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx \
- -e tmpfs=/run:rw,nosuid,nodev,exec,relatime,size=64M,uid=1000,gid=1000
+ --tmpfs=/run:rw,nosuid,nodev,exec,relatime,size=64M,uid=1000,gid=1000 \
  mikenye/adsbexchange
 ```
 


### PR DESCRIPTION
in case the tmpfs mount doesn't work or is omitted by the user, make
sure /run is owned by adsbx user so the container still works without
tmpfs